### PR TITLE
[BUG] Single column DataFrames in Models.ARIMA method and Assumptions class

### DIFF
--- a/examples/Models and Summary/assumptions.py
+++ b/examples/Models and Summary/assumptions.py
@@ -17,8 +17,12 @@ import qdatoolkit as qda
 # Import the dataset
 data = pd.DataFrame({'Ex5': [-0.14,-0.2,-0.33,-0.46,-0.48,-0.4,-0.28,-0.5,-0.45,-0.43,-0.41,-0.4,-0.36,-0.35,-0.21,-0.12,-0.31,-0.44,-0.33,-0.25,-0.28,-0.19,-0.3,-0.29,-0.29,-0.24,-0.08,-0.16,-0.17,-0.33,-0.11,-0.06,-0.13,-0.21,-0.15,-0.18,-0.12,0.02,0.06,-0.03,-0.08,-0.01,0.03,0.03,0.11,0.03,-0.05,-0.12,-0.09,-0.08,-0.15,-0.05,0.02,0.05,-0.16,-0.17,-0.25,0.02,0.09,0.03,-0.01,0,-0.02,0.02,-0.2,-0.18,-0.05,-0.08,-0.12,0.03,-0.05,-0.22,-0.08,0.06,-0.19,-0.15,-0.22,0.03,-0.05,0.05,0.07,0.09,0.06,0.25,0.03,-0.01,0.08,0.27,0.24,0.16,0.33,0.28,0.1,0.1,0.23,0.33,0.2,0.42]})
 
+"""
+since the data is a pd.Dataframe with 1 column, the input handles it already. no need to use the column name
+"""
+
 # Check the normality of the data
-qda.Assumptions(data['Ex5']).normality()
+qda.Assumptions(data).normality()
 
 # Check the independence of the data
-qda.Assumptions(data['Ex5']).independence()
+qda.Assumptions(data).independence()

--- a/qdatoolkit/models.py
+++ b/qdatoolkit/models.py
@@ -385,6 +385,12 @@ class Models:
         -------
         None
         """
+        if isinstance(x, pd.DataFrame):
+            if x.shape[1] == 1:
+                x = x.iloc[:, 0]
+            else:
+                raise TypeError("please pass a pd.Series instead or use one column")
+
         p=order[0]
         d=order[1]
         q=order[2]
@@ -654,7 +660,7 @@ class Assumptions:
         
         # check if passed data is a DataFrame, oen columned df or not
         elif isinstance(data, pd.DataFrame):
-            if data.shape[0]:
+            if data.shape[1] == 1:
                 data = data.iloc[:, 0]
             else:
                 raise TypeError("please pass a pd.Series instead or use one column")

--- a/qdatoolkit/models.py
+++ b/qdatoolkit/models.py
@@ -651,6 +651,14 @@ class Assumptions:
                 UserWarning
             )
             data = pd.Series(data)
+        
+        # check if passed data is a DataFrame, oen columned df or not
+        elif isinstance(data, pd.DataFrame):
+            if data.shape[0]:
+                data = data.iloc[:, 0]
+            else:
+                raise TypeError("please pass a pd.Series instead or use one column")
+            
         self.data = data.dropna()
 
     def normality(self, qqplot=True, test='anderson-darling'):


### PR DESCRIPTION
#### Reference Issues/PRs

None. I discovered it when inputting incompatible input types to Models.ARIMA method and Assumptions class

#### What does this implement/fix? Explain your changes.

Extends input handling in the ARIMA and Assumptions modules to accept single-column `pd.DataFrame` inputs, matching the flexibility users expect when piping pandas operations into the package. Multiple-column DataFrames will raise TypeError.

**Before this PR:**
- Accepted: `pd.Series` (either standalone or extracted from a DataFrame with df["col"]), `np.ndarray` (coerced to Series)
- Rejected with cryptic downstream errors: `pd.DataFrame` of any shape, even with df.shape[1] == 1

**After this PR:**
- `pd.DataFrame` with a single column: accepted, coerced to `pd.Series` using the column as the series
- `pd.DataFrame` with multiple columns: raises `TypeError` with an explicit message
- Existing `pd.Series` and `np.ndarray` paths unchanged

The same input-handling logic is applied in both modules. Written separately due to differences in the input handling nature of the two.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their reviewing time on?

- The `TypeError` message wording for multi-column DataFrames — should it guide users toward `df[["col"]]` selection, or stay minimal? (current implementation: explicitly stated)
- Whether the single-column coercion should preserve the DataFrame column name as the Series name (current implementation: yes).
- Test coverage for the new input paths.

#### Did you add any tests for the change?

No, but I modified the `Models and Summary/assumptions.py` file

#### Additional observations (not fixed in this PR)

While working on the Assumptions module, I noticed that `scipy.stats.anderson` emits a `FutureWarning` on scipy ≥ 1.17 because the `method` parameter is unspecified. Verified that passing `method='interpolated'` yields identical statistic values (which is all the module reads from the return object). Not fixed here because the package's current scipy floor is `>=1.7.3`, which predates the `method` parameter.

Proposed fix: either raise the floor, or limit the ceiling at scipy < 1.17

Also observed that the package computes Anderson-Darling p-values by hand despite scipy providing them natively in 1.17+. A future enhancement could migrate to scipy's native p-value calculation once the scipy floor is bumped.

#### Any other comments?

Happy to split into two separate PRs (one per module) if preferred. Kept together because the logic is identical and the diff is small.